### PR TITLE
Add a dedicated 'updater' docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,20 @@ If the supplied API key matches the expected value, the locally stored JSON data
 
 If the API key doesn't match, the app. will return a 403 error.
 
-## Updating the docker image
+### Updater image
+
+The `updater-image/` directory maintains a docker image which can be used to update the JSON data in the app. See the `makefile` in that directory for a usage example.
+
+## Updating the docker images
 
 Pre-requisites: You need push access to the `ministryofjustice` repo on [docker hub]
 
-To update the docker image:
+To update the app. docker image:
 
  * make and commit your changes
  * update the tag value of `IMAGE` in the `makefile`
  * run `make`
 
-This will build the docker image and push it to docker hub, using the updated tag value.
+To update the updater image, repeat these steps in the `updater-image/` directory.
+
+This will build the docker images and push them to docker hub, using the updated tag values.

--- a/makefile
+++ b/makefile
@@ -1,13 +1,11 @@
 IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we:0.2
 
-build: .built-image
-
 .built-image: app.rb Gemfile* makefile views/*
 	docker build -t $(IMAGE) .
 	docker push $(IMAGE)
 	touch .built-image
 
-run: build
+run: .built-image
 	docker run --rm \
 		-p 4567:4567 \
 		-e API_KEY=soopersekrit \

--- a/updater-image/Dockerfile
+++ b/updater-image/Dockerfile
@@ -1,0 +1,25 @@
+FROM python:alpine3.10
+
+ENV \
+  HELM_VERSION=2.14.3 \
+  KUBECTL_VERSION=1.15.0
+
+RUN pip install awscli
+RUN apk add curl libc6-compat git
+
+# Install helm
+RUN curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -xzC /usr/local/bin --strip-components 1 linux-amd64/helm
+
+RUN apk add bash
+
+# Install kubectl
+RUN curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+RUN chmod 755 /usr/local/bin/kubectl
+
+RUN helm init --client-only
+RUN helm repo add jetstack https://charts.jetstack.io
+RUN helm plugin install https://github.com/bacongobbler/helm-whatup
+
+WORKDIR /app
+COPY update.sh /app/
+

--- a/updater-image/makefile
+++ b/updater-image/makefile
@@ -1,0 +1,20 @@
+IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:1.0
+
+.built-image: Dockerfile makefile update.sh
+	docker build -t $(IMAGE) .
+	docker push $(IMAGE)
+	touch .built-image
+
+# This is only required during development. Normally, the concourse
+# pipeline does this.
+run: .built-image
+	docker run \
+		-e AWS_ACCESS_KEY_ID=$${AWS_ACCESS_KEY_ID} \
+		-e AWS_SECRET_ACCESS_KEY=$${AWS_SECRET_ACCESS_KEY} \
+		-e KUBECONFIG_S3_BUCKET=$${KUBECONFIG_S3_BUCKET} \
+		-e KUBECONFIG_S3_KEY=$${KUBECONFIG_S3_KEY} \
+		-e KUBECONFIG=$${KUBECONFIG} \
+		-e KUBE_CLUSTER=$${KUBE_CLUSTER} \
+		-e HTTP_ENDPOINT=$${HTTP_ENDPOINT} \
+	  --rm -it $(IMAGE) \
+		./update.sh

--- a/updater-image/update.sh
+++ b/updater-image/update.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -euo pipefail
+
+aws s3 cp s3://${KUBECONFIG_S3_BUCKET}/${KUBECONFIG_S3_KEY} /tmp/kubeconfig
+kubectl config use-context ${KUBE_CLUSTER}
+
+helm repo update
+
+curl -H "X-API-KEY: $(kubectl -n how-out-of-date-are-we get secrets how-out-of-date-are-we-api-key -o jsonpath='{.data.token}' | base64 -d)" -d "$(helm whatup -o json)" ${HTTP_ENDPOINT}


### PR DESCRIPTION
Until now, the concourse pipeline has been using
the main 'cloud-platform tools' docker image, and
installing any required packages on top of that.

This is overkill, because the tools image has lots
of software which is not required.

This change adds a dedicated image with the
minimal software installed to update the JSON data
in the app. This should enable the concourse
pipeline to be simplified, in a later change.