### PR TITLE
Use absolute path in `update.sh` script

### DIFF
--- a/updater-image/makefile
+++ b/updater-image/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:1.2
+IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:1.4
 
 .built-image: Dockerfile makefile update.sh module-versions.rb
 	docker build -t $(IMAGE) .

--- a/updater-image/update.sh
+++ b/updater-image/update.sh
@@ -24,7 +24,7 @@ terraform_modules() {
   git clone --depth 1 https://github.com/ministryofjustice/cloud-platform-environments.git
   (
     cd cloud-platform-environments
-    curl -H "X-API-KEY: ${API_KEY}" -d "$(../module-versions.rb)" ${DATA_URL}/terraform_modules
+    curl -H "X-API-KEY: ${API_KEY}" -d "$(/app/module-versions.rb)" ${DATA_URL}/terraform_modules
   )
 }
 


### PR DESCRIPTION
Apparently, concourse pipelines ignore the docker image WORKDIR, and execute
whatever command you specify from the root directory of the docker image.

This version of the updater image uses the absolute path to the ruby script.