### PR TITLE
Use the cloud-platform-repository-checker gem

### DIFF
--- a/updater-image/Dockerfile
+++ b/updater-image/Dockerfile
@@ -17,10 +17,3 @@ RUN pip install awscli \
 
 WORKDIR /app
 COPY *.sh *.rb /app/
-
-RUN addgroup -g 1000 -S appgroup \
-  && adduser -u 1000 -S appuser -G appgroup \
-  && chown -R appuser:appgroup /app
-
-USER 1000
-

--- a/updater-image/Dockerfile
+++ b/updater-image/Dockerfile
@@ -12,7 +12,8 @@ RUN pip install awscli \
   && chmod 755 /usr/local/bin/kubectl \
   && helm init --client-only \
   && helm repo add jetstack https://charts.jetstack.io \
-  && helm plugin install https://github.com/bacongobbler/helm-whatup
+  && helm plugin install https://github.com/bacongobbler/helm-whatup \
+  && gem install cloud-platform-repository-checker -v 1.0.4 --no-rdoc --no-doc
 
 WORKDIR /app
 COPY *.sh *.rb /app/

--- a/updater-image/Dockerfile
+++ b/updater-image/Dockerfile
@@ -17,3 +17,10 @@ RUN pip install awscli \
 
 WORKDIR /app
 COPY *.sh *.rb /app/
+
+RUN addgroup -g 1000 -S appgroup \
+  && adduser -u 1000 -S appuser -G appgroup \
+  && chown -R appuser:appgroup /app
+
+USER 1000
+

--- a/updater-image/makefile
+++ b/updater-image/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:2.1
+IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:2.2
 
 .built-image: Dockerfile makefile update.sh module-versions.rb documentation-pages-to-review.rb helm-releases.rb
 	docker build -t $(IMAGE) .

--- a/updater-image/makefile
+++ b/updater-image/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:2.2
+IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:2.3
 
 .built-image: Dockerfile makefile update.sh module-versions.rb documentation-pages-to-review.rb helm-releases.rb
 	docker build -t $(IMAGE) .

--- a/updater-image/update.sh
+++ b/updater-image/update.sh
@@ -48,14 +48,7 @@ documentation() {
 }
 
 repositories() {
-  json=$(docker run --rm \
-    -e GITHUB_TOKEN=${GITHUB_TOKEN} \
-    -e ORGANIZATION=${ORGANIZATION} \
-    -e TEAM=${TEAM} \
-    -e REGEXP=${REGEXP} \
-    ministryofjustice/cloud-platform-repository-checker:1.1)
-
-  curl -H "X-API-KEY: ${API_KEY}" -d "${json}" ${DATA_URL}/repositories
+  curl -H "X-API-KEY: ${API_KEY}" -d "$(cloud-platform-repository-checker)" ${DATA_URL}/repositories
 }
 
 main


### PR DESCRIPTION
This version uses the ruby gem in the updater. This means we're not trying to
run docker in docker, when the updater is invoked via the concourse pipeline.