### PR TITLE
Tolerate malformed JSON data files

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -41,9 +41,17 @@ def fetch_data(docpath, key)
   }
 
   if FileTest.exists?(file)
-    data = JSON.parse(File.read file)
-    updated_at = string_to_formatted_time(data.fetch("updated_at"))
-    list = data.fetch(key)
+    data = {}
+    list = []
+    updated_at = nil
+
+    begin
+      data = JSON.parse(File.read file)
+      updated_at = string_to_formatted_time(data.fetch("updated_at"))
+      list = data.fetch(key)
+    rescue JSON::ParserError
+      logger.info "Malformed JSON file: #{file}"
+    end
 
     # Do any pre-processing to the list we get from the data file
     yield list if block_given?

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we:2.1
+IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we:2.2
 
 .built-image: app.rb Gemfile* makefile views/*
 	docker build -t $(IMAGE) .

--- a/spec/dev_server_spec.rb
+++ b/spec/dev_server_spec.rb
@@ -5,6 +5,8 @@ require "spec_helper"
 #     make dev-server
 #
 
+HELM_RELEASE_DATA_FILE = "data/helm_whatup.json"
+
 describe "local dev server" do
   let(:base_url) { "http://localhost:4567" }
   let(:api_key) { "soopersekrit" } # specified in makefile
@@ -28,6 +30,17 @@ describe "local dev server" do
   it "serves pages" do
     urls.each do |url|
       response = fetch_url(url)
+      expect(response.code).to eq("200")
+    end
+  end
+
+  context "with malformed json data" do
+    before do
+      File.write(HELM_RELEASE_DATA_FILE, " ")
+    end
+
+    it "does not crash" do
+      response = fetch_url(helm_whatup_url)
       expect(response.code).to eq("200")
     end
   end


### PR DESCRIPTION
The web app. was crashing with a 500 error if the data file existed, but
did not contain valid json. This change allows the app. to carry on,
treating malformed data as no data.