### PR TITLE
Update HOODAW for helm3

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -72,7 +72,7 @@ end
 get "/helm_whatup" do
   fetch_data("helm_whatup", "clusters") do |clusters|
     clusters.each do |cluster|
-      cluster.fetch("apps").map { |app| app["trafficLight"] = version_lag_traffic_light(app) }
+      cluster.fetch("apps").map { |app| app["traffic_light"] = version_lag_traffic_light(app) }
     end
   end
 end

--- a/helpers.rb
+++ b/helpers.rb
@@ -3,8 +3,8 @@ helpers do
   # how far behind latest the installed version
   # is.
   def version_lag_traffic_light(app)
-    installed = app.fetch("installedVersion").split(".")
-    latest = app.fetch("latestVersion").split(".")
+    installed = app.fetch("installed_version").split(".")
+    latest = app.fetch("latest_version").split(".")
 
     major_diff = latest[0].to_i - installed[0].to_i
     minor_diff = latest[1].to_i - installed[1].to_i

--- a/makefile
+++ b/makefile
@@ -12,6 +12,7 @@ run:
 	docker-compose up --build
 
 update:
+	docker-compose build updater
 	docker-compose run updater ./update.sh
 
 # Ensure you have a data/helm-whatup.json file

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we:2.2
+IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we:2.3
 
 .built-image: app.rb Gemfile* makefile views/*
 	docker build -t $(IMAGE) .

--- a/updater-image/Dockerfile
+++ b/updater-image/Dockerfile
@@ -1,16 +1,15 @@
 FROM python:alpine3.10
 
 ENV \
-  HELM_VERSION=2.14.3 \
+  HELM_VERSION=3.2.1 \
   KUBECTL_VERSION=1.15.0
 
 RUN pip install awscli \
   && apk add curl libc6-compat git bash ruby ruby-nokogiri \
   && gem install json_pure --no-rdoc --no-ri \
-  && curl -sL https://storage.googleapis.com/kubernetes-helm/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -xzC /usr/local/bin --strip-components 1 linux-amd64/helm \
+  && curl -sL https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.tar.gz | tar -xzC /usr/local/bin --strip-components 1 linux-amd64/helm \
   && curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
   && chmod 755 /usr/local/bin/kubectl \
-  && helm init --client-only \
   && helm repo add stable https://kubernetes-charts.storage.googleapis.com/ \
   && helm repo add jetstack https://charts.jetstack.io/ \
   && helm repo add concourse https://concourse-charts.storage.googleapis.com/ \

--- a/updater-image/Dockerfile
+++ b/updater-image/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install awscli \
   && chmod 755 /usr/local/bin/kubectl \
   && helm init --client-only \
   && helm repo add jetstack https://charts.jetstack.io \
-  && helm plugin install https://github.com/bacongobbler/helm-whatup \
+  && helm plugin install https://github.com/fabmation-gmbh/helm-whatup \
   && gem install cloud-platform-repository-checker -v 1.0.4 --no-rdoc --no-doc
 
 WORKDIR /app

--- a/updater-image/Dockerfile
+++ b/updater-image/Dockerfile
@@ -11,7 +11,10 @@ RUN pip install awscli \
   && curl -sLo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl \
   && chmod 755 /usr/local/bin/kubectl \
   && helm init --client-only \
-  && helm repo add jetstack https://charts.jetstack.io \
+  && helm repo add stable https://kubernetes-charts.storage.googleapis.com/ \
+  && helm repo add jetstack https://charts.jetstack.io/ \
+  && helm repo add concourse https://concourse-charts.storage.googleapis.com/ \
+  && helm repo add cloud-platform https://ministryofjustice.github.io/cloud-platform-helm-charts \
   && helm plugin install https://github.com/fabmation-gmbh/helm-whatup \
   && gem install cloud-platform-repository-checker -v 1.0.4 --no-rdoc --no-doc
 

--- a/updater-image/makefile
+++ b/updater-image/makefile
@@ -1,4 +1,4 @@
-IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:2.3
+IMAGE := ministryofjustice/cloud-platform-how-out-of-date-are-we-updater:2.4
 
 .built-image: Dockerfile makefile update.sh module-versions.rb documentation-pages-to-review.rb helm-releases.rb
 	docker build -t $(IMAGE) .

--- a/views/helm_whatup.erb
+++ b/views/helm_whatup.erb
@@ -4,17 +4,18 @@
   <div class="row">
     <% cluster["apps"].each do |app| %>
 
-      <div class="card text-white bg-<%= app["trafficLight"] %> mb-3 mr-3" style="max-width: 18rem;">
+      <div class="card text-white bg-<%= app["traffic_light"] %> mb-3 mr-3" style="max-width: 18rem;">
 
         <div class="card-header">
-          <h5 class="card-title"><%= app["releaseName"] %></h5>
+          <h5 class="card-title"><%= app["name"] %></h5>
         </div>
 
         <div class="card-body">
           <ul>
-            <li>chart: <%= app["chartName"] %></li>
-            <li>installed: <%= app["installedVersion"] %></li>
-            <li>latest: <%= app["latestVersion"] %></li>
+            <li>chart: <%= app["chart"] %></li>
+            <li>namespace: <%= app["namespace"] %></li>
+            <li>installed: <%= app["installed_version"] %></li>
+            <li>latest: <%= app["latest_version"] %></li>
           </ul>
         </div>
 


### PR DESCRIPTION
This uses a different version of the `helm-whatup` plugin,
and requires some changes for tillerless helm3.