### PR TITLE
Add github action to publish webapp. docker image

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,20 @@
+name: Publish docker image
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  push_to_registry:
+    name: Push image to docker hub
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: Push to docker hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          repository: ministryofjustice/cloud-platform-how-out-of-date-are-we
+          tag_with_ref: true


### PR DESCRIPTION
This action will build and push a tagged docker image to docker hub,
whenever a release is created.

This will not publish the updater docker image yet, so that still needs
to be done manually, for now.