### PR TITLE
Add a dashboard page to the HOODAW web app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ It requires a github personal access token with `public_repo` scope.
 
 See the `docker-compose.yml` file for details of how to run this app. and the updater script locally.
 
+If you're just working on the web application, another option is to run:
+
+```
+bundle install
+make fetch-live-json-datafiles
+make dev-server
+```
+
+This will launch a local instance of the web server, and populate the data
+directory with the latest JSON files from the live instance.
+
+NB: You will need a workin ruby environment.
+
 ## Updating the docker images
 
 After code changes, create a new [release] via the github web interface.

--- a/app.rb
+++ b/app.rb
@@ -29,6 +29,39 @@ def require_api_key(request)
   end
 end
 
+def dashboard_data
+  # TODO: there is a lot of duplication here from the code for the individual docpaths. Fix that.
+  updated = []
+
+  terraform_modules, updated_at = get_list_and_updated_at(datafile("terraform_modules"), "out_of_date_modules")
+  updated << updated_at
+
+  documentation_pages, updated_at = get_list_and_updated_at(datafile("documentation"), "pages")
+  updated << updated_at
+
+  repositories, updated_at = get_list_and_updated_at(datafile("repositories"), "repositories")
+  repositories.reject! { |repo| repo["status"] == "PASS" }
+  updated << updated_at
+
+  clusters, updated_at = get_list_and_updated_at(datafile("helm_whatup"), "clusters")
+  out_of_date_apps = clusters.map { |cluster| cluster.fetch("apps") }.flatten
+    .filter { |app| version_lag_traffic_light(app) == "danger" }
+  updated << updated_at
+
+  {
+    updated_at: updated.sort.first,
+    data: {
+      action_items: {
+        helm_whatup: out_of_date_apps.length,
+        terraform_modules: terraform_modules.length,
+        documentation: documentation_pages.length,
+        repositories: repositories.length,
+      },
+      action_required: true
+    }
+  }
+end
+
 # key is the name of the key in our datafile which contains the list of
 # elements we're interested in.
 def fetch_data(docpath, key)
@@ -75,19 +108,9 @@ get "/" do
 end
 
 get "/dashboard" do
-  locals = {
+  locals = dashboard_data.merge(
     active_nav: "/dashboard",
-    updated_at: nil,
-    data: {
-      action_items: {
-        helm_whatup: 1,
-        terraform_modules: 2,
-        documentation: 0,
-        repositories: 3
-      },
-      action_required: true
-    }
-  }
+  )
   erb :dashboard, locals: locals
 end
 

--- a/app.rb
+++ b/app.rb
@@ -41,7 +41,6 @@ def fetch_data(docpath, key)
   }
 
   if FileTest.exists?(file)
-    data = {}
     list = []
     updated_at = nil
 

--- a/app.rb
+++ b/app.rb
@@ -66,7 +66,15 @@ def fetch_data(docpath, key)
 end
 
 get "/" do
-  redirect "/helm_whatup"
+  redirect "/dashboard"
+end
+
+get "/dashboard" do
+  locals = {
+    active_nav: "/dashboard",
+    updated_at: nil
+  }
+  erb :dashboard, locals: locals
 end
 
 get "/helm_whatup" do

--- a/app.rb
+++ b/app.rb
@@ -72,7 +72,16 @@ end
 get "/dashboard" do
   locals = {
     active_nav: "/dashboard",
-    updated_at: nil
+    updated_at: nil,
+    data: {
+      action_items: {
+        helm_whatup: 1,
+        terraform_modules: 2,
+        documentation: 0,
+        repositories: 3
+      },
+      action_required: true
+    }
   }
   erb :dashboard, locals: locals
 end

--- a/app.rb
+++ b/app.rb
@@ -41,16 +41,7 @@ def fetch_data(docpath, key)
   }
 
   if FileTest.exists?(file)
-    list = []
-    updated_at = nil
-
-    begin
-      data = JSON.parse(File.read file)
-      updated_at = string_to_formatted_time(data.fetch("updated_at"))
-      list = data.fetch(key)
-    rescue JSON::ParserError
-      logger.info "Malformed JSON file: #{file}"
-    end
+    list, updated_at = get_list_and_updated_at(file, key)
 
     # Do any pre-processing to the list we get from the data file
     yield list if block_given?
@@ -62,6 +53,21 @@ def fetch_data(docpath, key)
   end
 
   erb template, locals: locals
+end
+
+def get_list_and_updated_at(file, key)
+  list = []
+  updated_at = nil
+
+  begin
+    data = JSON.parse(File.read file)
+    updated_at = string_to_formatted_time(data.fetch("updated_at"))
+    list = data.fetch(key)
+  rescue JSON::ParserError
+    logger.info "Malformed JSON file: #{file}"
+  end
+
+  [list, updated_at]
 end
 
 get "/" do

--- a/makefile
+++ b/makefile
@@ -4,3 +4,10 @@ dev-server:
 # These tests require the dev-server above to be running
 test:
 	rspec
+
+fetch-live-json-datafiles:
+	pod=$$(kubectl -n how-out-of-date-are-we get pods -o name); \
+		for file in $$(kubectl -n how-out-of-date-are-we exec $${pod} ls data); do \
+		  echo $${file}; \
+			kubectl -n how-out-of-date-are-we exec $${pod} cat data/$${file} > data/$${file}; \
+		done

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -4,22 +4,30 @@
 
 <table class="table table-striped">
   <tr>
-    <td>Helm Releases</td>
+    <td>
+      <a href="/helm_whatup">Helm Releases</a>
+    </td>
     <td><%= action_items[:helm_whatup] %></td>
   </tr>
 
   <tr>
-    <td>Terraform Modules</td>
+    <td>
+      <a href="/terraform_modules">Terraform Modules</a>
+    </td>
     <td><%= action_items[:terraform_modules] %></td>
   </tr>
 
   <tr>
-    <td>Documentation Pages</td>
+    <td>
+      <a href="/documentation">Documentation Pages</a>
+    </td>
     <td><%= action_items[:documentation] %></td>
   </tr>
 
   <tr>
-    <td>GitHub Repositories</td>
+    <td>
+      <a href="/repositories">GitHub Repositories</a>
+    </td>
     <td><%= action_items[:repositories] %></td>
   </tr>
 </table>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,0 +1,12 @@
+<h1>Dashboard</h1>
+
+<div class="row">
+  <div class="card text-white bg-danger mb-3 mr-3" style="max-width: 18rem;">
+    <div class="card-header">
+      <h5 class="card-title">Something</h5>
+    </div>
+    <div class="card-body">
+      Whatever
+    </div>
+  </div>
+</div>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -1,12 +1,25 @@
-<h1>Dashboard</h1>
+<h2>Action Items</h2>
 
-<div class="row">
-  <div class="card text-white bg-danger mb-3 mr-3" style="max-width: 18rem;">
-    <div class="card-header">
-      <h5 class="card-title">Something</h5>
-    </div>
-    <div class="card-body">
-      Whatever
-    </div>
-  </div>
-</div>
+<% action_items = locals[:data][:action_items] %>
+
+<table class="table">
+  <tr>
+    <td>Helm Releases</td>
+    <td><%= action_items[:helm_whatup] %></td>
+  </tr>
+
+  <tr>
+    <td>Terraform Modules</td>
+    <td><%= action_items[:terraform_modules] %></td>
+  </tr>
+
+  <tr>
+    <td>Documentation Pages</td>
+    <td><%= action_items[:documentation] %></td>
+  </tr>
+
+  <tr>
+    <td>GitHub Repositories</td>
+    <td><%= action_items[:repositories] %></td>
+  </tr>
+</table>

--- a/views/dashboard.erb
+++ b/views/dashboard.erb
@@ -2,7 +2,7 @@
 
 <% action_items = locals[:data][:action_items] %>
 
-<table class="table">
+<table class="table table-striped">
   <tr>
     <td>Helm Releases</td>
     <td><%= action_items[:helm_whatup] %></td>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -18,6 +18,9 @@
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
         <ul class="navbar-nav mr-auto">
+          <li class="nav-item <%= active_nav == "dashboard" ? "active" : "" %>">
+            <a class="nav-link" href="/dashboard">Dashboard</a>
+          </li>
           <li class="nav-item <%= active_nav == "helm_whatup" ? "active" : "" %>">
             <a class="nav-link" href="/helm_whatup">Helm Releases</a>
           </li>


### PR DESCRIPTION

![Screenshot 2020-06-22 at 16 06 32](https://user-images.githubusercontent.com/2338/85303435-61660900-b4a2-11ea-90e3-652bdd00b923.png)

This enables us to check a single page to find out the overall state of the
platform, wrt. how much work there is to do in order to bring things up to
date.

This is intended to form the basis of a daily slack update (if there is
anything we need to do).