### PR TITLE
Prevent errors if any json files missing

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -49,7 +49,7 @@ def dashboard_data
   updated << updated_at
 
   {
-    updated_at: updated.sort.first,
+    updated_at: updated.compact.sort.first,
     data: {
       action_items: {
         helm_whatup: out_of_date_apps.length,


### PR DESCRIPTION
If a json file is missing, there will be a nil value in `updated` and
the app. will error when trying to sort the list. Adding `compact` will
skip any nil values.