### PR TITLE
Dashboard summary

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -27,7 +27,7 @@ jobs:
           repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
           tag_with_ref: true
       - name: Compile the dashboard-reporter script
-        run: make
+        run: cd dashboard-reporter/; make
       - name: Push dashboard-reporter to docker hub
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -26,3 +26,13 @@ jobs:
           path: updater-image
           repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-updater
           tag_with_ref: true
+      - name: Compile the dashboard-reporter script
+        run: make
+      - name: Push dashboard-reporter to docker hub
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          path: dashboard-reporter
+          repository: ministryofjustice/cloud-platform-how-out-of-date-are-we-reporter
+          tag_with_ref: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .built-image
+dashboard-reporter/report.rb

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # How out of date are we?
 
-Simple web app. to display a traffic light view of how far our installed software is behind the current versions, and how many of our documentation pages are overdue for review.
+Simple web app. to display various status information including:
+
+* a traffic light view of how far our installed helm charts are behind the latest versions
+* documentation pages which are overdue for review.
+* namespaces in the environments repository which use versions of our terraform modules which are not the latest
+* ministryofjustice/cloud-platform-\* github repositories whose settings do not match our requirements
 
 ![Screenshot of the app](screenshot.png?raw=true "Example screenshot")
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Simple web app. to display various status information including:
 
 The app. accepts posted JSON data from an updater image, defined in the [updater-image] directory.
 
+## Dashboard Reporter
+
+The `dashboard-reporter` directory maintains a script which will
+generate a report, formatted for use as a slack message,
+containing the information on the dashboard page of the web
+application.
+
+The code in the reporter script is built from classes defined in the main
+project, purely so that we can keep the Dockerfile simple and just add a single
+ruby script to the default ruby alpine image without having to install gems
+etc.
+
 ## Updating the JSON data
 
 ### Helm releases

--- a/dashboard-reporter/Dockerfile
+++ b/dashboard-reporter/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.6-alpine
+
+WORKDIR /app
+COPY report.rb /app
+ENTRYPOINT ["ruby", "/app/report.rb"]

--- a/dashboard-reporter/README.md
+++ b/dashboard-reporter/README.md
@@ -1,0 +1,19 @@
+# Dashboard Reporter
+
+This directory maintains a `report.rb` ruby script which
+consumes the HOODAW dashboard JSON endpoint and posts a summary
+to the team slack channel iff there are outstanding action
+items.
+
+The main `DashboardReporter` class is defined in the `lib`
+directory (a sibling to this directory) so that we can take
+advantage of the rspec test framework.
+
+The `makefile` in this directory creates `report.rb` by
+concatenating the `../lib/dashboard_reporter.rb` file with a
+header and `footer.rb` file.
+
+The `.github/workflows/docker-hub.yml` file defines a github
+action with runs the makefile and then builds and pushes the
+docker image to docker hub whenever a new release of this
+project is created.

--- a/dashboard-reporter/footer.rb
+++ b/dashboard-reporter/footer.rb
@@ -1,0 +1,15 @@
+############################################################
+
+url = ENV.fetch("DASHBOARD_URL")
+output_file = ENV.fetch("OUTPUT_FILE")
+timestamp = Time.now.strftime("%Y-%m-%d %H:%M:%S")
+
+report = [DashboardReporter.new(url).slack_formatted_report, timestamp].join("\n")
+
+if report == ""
+  puts "#{timestamp} No action items reported."
+else
+  puts report # <-- so we see it in the concourse log
+  File.open(output_file, "w") { |f| f.puts report }
+  exit 1
+end

--- a/dashboard-reporter/makefile
+++ b/dashboard-reporter/makefile
@@ -1,0 +1,7 @@
+SCRIPTFILE := report.rb
+
+$(SCRIPTFILE): footer.rb ../lib/dashboard_reporter.rb
+	echo "#!/usr/bin/env ruby\n\n" > $(SCRIPTFILE)
+	cat ../lib/dashboard_reporter.rb >> $(SCRIPTFILE)
+	cat footer.rb >> $(SCRIPTFILE)
+	chmod 755 $(SCRIPTFILE)

--- a/lib/dashboard_reporter.rb
+++ b/lib/dashboard_reporter.rb
@@ -8,16 +8,23 @@ class DashboardReporter
     @dashboard_url = url
   end
 
-  def report
+  def slack_formatted_report
     return "" unless action_required?
+
+    items = data.fetch("data").fetch("action_items")
+    item_keys = items.keys.sort
+    max_key_length = item_keys.map(&:length).max
+
+    action_items = item_keys.map do |key|
+      value = items[key]
+      label = "#{key}:".ljust(max_key_length + 1)
+      [label, value].join(" ")
+    end
 
     %(
 How out of date are we - action required:
 ```
-documentation:     1
-helm_whatup:       1
-repositories:      3
-terraform_modules: 0
+#{action_items.join("\n")}
 ```
     ).strip
   end

--- a/lib/dashboard_reporter.rb
+++ b/lib/dashboard_reporter.rb
@@ -1,9 +1,23 @@
+require "open-uri"
+require "json"
+
 class DashboardReporter
-  def action_required?
-    fetch_data.fetch("data").fetch("action_required")
+  attr_reader :dashboard_url
+
+  def initialize(url)
+    @dashboard_url = url
   end
 
-  def fetch_data
-    @data ||= {}
+  def action_required?
+    data.fetch("data").fetch("action_required")
+  end
+
+  private
+
+  def data
+    @data ||= begin
+      json = URI.open(url, "Accept" => "application/json") { |f| f.read }
+      JSON.parse(json)
+    end
   end
 end

--- a/lib/dashboard_reporter.rb
+++ b/lib/dashboard_reporter.rb
@@ -8,11 +8,25 @@ class DashboardReporter
     @dashboard_url = url
   end
 
-  def action_required?
-    data.fetch("data").fetch("action_required")
+  def report
+    return "" unless action_required?
+
+    %(
+How out of date are we - action required:
+```
+documentation:     1
+helm_whatup:       1
+repositories:      3
+terraform_modules: 0
+```
+    ).strip
   end
 
   private
+
+  def action_required?
+    data.fetch("data").fetch("action_required")
+  end
 
   def data
     @data ||= begin

--- a/lib/dashboard_reporter.rb
+++ b/lib/dashboard_reporter.rb
@@ -22,7 +22,7 @@ class DashboardReporter
     end
 
     %(
-How out of date are we - action required:
+Action items:
 ```
 #{action_items.join("\n")}
 ```

--- a/lib/dashboard_reporter.rb
+++ b/lib/dashboard_reporter.rb
@@ -1,0 +1,9 @@
+class DashboardReporter
+  def action_required?
+    fetch_data.fetch("data").fetch("action_required")
+  end
+
+  def fetch_data
+    @data ||= {}
+  end
+end

--- a/lib/dashboard_reporter.rb
+++ b/lib/dashboard_reporter.rb
@@ -37,7 +37,7 @@ How out of date are we - action required:
 
   def data
     @data ||= begin
-      json = URI.open(url, "Accept" => "application/json") { |f| f.read }
+      json = URI.open(dashboard_url, "Accept" => "application/json") { |f| f.read }
       JSON.parse(json)
     end
   end

--- a/spec/dashboard_reporter_spec.rb
+++ b/spec/dashboard_reporter_spec.rb
@@ -1,0 +1,51 @@
+require "spec_helper"
+
+describe DashboardReporter do
+
+  let(:data) { {
+    "updated_at" =>"2020-07-20 09:27:44",
+    "data" => {
+      "action_items" => {
+        "documentation" => 1,
+        "helm_whatup" => 1,
+        "repositories" => 3,
+        "terraform_modules" => 0
+      },
+      "action_required" => action_required
+    }
+  } }
+
+  subject(:dr) { described_class.new }
+
+  before do
+    allow(dr).to receive(:fetch_data).and_return(data)
+  end
+
+  describe "action_required?" do
+    context "when there are no open todo items" do
+      let(:action_required) { false }
+
+      it "reports nothing to do" do
+        expect(dr.action_required?).to be false
+      end
+    end
+
+    context "when there are open todo items" do
+      let(:action_required) { true }
+
+      it "reports something to do" do
+        expect(dr.action_required?).to be true
+      end
+    end
+
+    context "when data is incorrectly structured" do
+      let(:data) { { "foo" => "bar" } }
+
+      it "raises an error" do
+        expect{
+          dr.action_required?
+        }.to raise_error(KeyError)
+      end
+    end
+  end
+end

--- a/spec/dashboard_reporter_spec.rb
+++ b/spec/dashboard_reporter_spec.rb
@@ -15,7 +15,7 @@ describe DashboardReporter do
   } }
 
   let(:formatted_message) { %(
-How out of date are we - action required:
+Action items:
 ```
 documentation:     1
 helm_whatup:       1

--- a/spec/dashboard_reporter_spec.rb
+++ b/spec/dashboard_reporter_spec.rb
@@ -36,7 +36,7 @@ terraform_modules: 0
     let(:action_required) { false }
 
     it "returns empty string" do
-      expect(dr.report).to eq("")
+      expect(dr.slack_formatted_report).to eq("")
     end
   end
 
@@ -44,7 +44,7 @@ terraform_modules: 0
     let(:action_required) { true }
 
     it "formats the report for posting to slack" do
-      expect(dr.report).to eq(formatted_message)
+      expect(dr.slack_formatted_report).to eq(formatted_message)
     end
   end
 
@@ -53,7 +53,7 @@ terraform_modules: 0
 
     it "raises an error" do
       expect{
-        dr.report
+        dr.slack_formatted_report
       }.to raise_error(KeyError)
     end
   end

--- a/spec/dashboard_reporter_spec.rb
+++ b/spec/dashboard_reporter_spec.rb
@@ -14,6 +14,16 @@ describe DashboardReporter do
     }
   } }
 
+  let(:formatted_message) { %(
+How out of date are we - action required:
+```
+documentation:     1
+helm_whatup:       1
+repositories:      3
+terraform_modules: 0
+```
+                            ).strip }
+
   let(:dashboard_url) { "" }
 
   subject(:dr) { described_class.new(dashboard_url) }
@@ -22,31 +32,29 @@ describe DashboardReporter do
     allow(dr).to receive(:data).and_return(data)
   end
 
-  describe "action_required?" do
-    context "when there are no open todo items" do
-      let(:action_required) { false }
+  context "when there are no open todo items" do
+    let(:action_required) { false }
 
-      it "reports nothing to do" do
-        expect(dr.action_required?).to be false
-      end
+    it "returns empty string" do
+      expect(dr.report).to eq("")
     end
+  end
 
-    context "when there are open todo items" do
-      let(:action_required) { true }
+  context "when there are open todo items" do
+    let(:action_required) { true }
 
-      it "reports something to do" do
-        expect(dr.action_required?).to be true
-      end
+    it "formats the report for posting to slack" do
+      expect(dr.report).to eq(formatted_message)
     end
+  end
 
-    context "when data is incorrectly structured" do
-      let(:data) { { "foo" => "bar" } }
+  context "when data is incorrectly structured" do
+    let(:data) { { "foo" => "bar" } }
 
-      it "raises an error" do
-        expect{
-          dr.action_required?
-        }.to raise_error(KeyError)
-      end
+    it "raises an error" do
+      expect{
+        dr.report
+      }.to raise_error(KeyError)
     end
   end
 end

--- a/spec/dashboard_reporter_spec.rb
+++ b/spec/dashboard_reporter_spec.rb
@@ -1,7 +1,6 @@
 require "spec_helper"
 
 describe DashboardReporter do
-
   let(:data) { {
     "updated_at" =>"2020-07-20 09:27:44",
     "data" => {
@@ -15,10 +14,12 @@ describe DashboardReporter do
     }
   } }
 
-  subject(:dr) { described_class.new }
+  let(:dashboard_url) { "" }
+
+  subject(:dr) { described_class.new(dashboard_url) }
 
   before do
-    allow(dr).to receive(:fetch_data).and_return(data)
+    allow(dr).to receive(:data).and_return(data)
   end
 
   describe "action_required?" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,7 @@ require "json"
 require "pry-byebug"
 require "sinatra"
 require "./lib/hoodaw"
+require "./lib/dashboard_reporter"
 
 def fetch_url(url, accept = nil)
   uri = URI.parse(url)


### PR DESCRIPTION
Add a dashboard-reporter script (built from the DashboardReporter class in the lib directory), and a build process to publish a docker image to docker hub.

A concourse pipeline will use this docker image to post a slack message to #cloud-platform every day, if there are outstanding action items.

co-authored with @pwyborn 