### PR TITLE
Add JSON endpoints for all the HOODAW report pages

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -120,11 +120,21 @@ get "/helm_whatup" do
 end
 
 get "/documentation" do
-  render_item_list("documentation", "pages", Documentation)
+  accept = request.env["HTTP_ACCEPT"]
+  if accept == CONTENT_TYPE_JSON
+     serve_json_data(:documentation)
+  else
+    render_item_list("documentation", "pages", Documentation)
+  end
 end
 
 get "/terraform_modules" do
-  render_item_list("terraform_modules", "out_of_date_modules")
+  accept = request.env["HTTP_ACCEPT"]
+  if accept == CONTENT_TYPE_JSON
+     serve_json_data(:terraform_modules)
+  else
+    render_item_list("terraform_modules", "out_of_date_modules")
+  end
 end
 
 get "/repositories" do

--- a/app.rb
+++ b/app.rb
@@ -72,7 +72,7 @@ def get_data_from_json_file(docpath, key, klass)
 end
 
 def serve_json_data(docpath)
-  File.read(datafile(:helm_whatup))
+  File.read(datafile(docpath))
 end
 
 # key is the name of the key in our datafile which contains the list of

--- a/app.rb
+++ b/app.rb
@@ -138,7 +138,12 @@ get "/terraform_modules" do
 end
 
 get "/repositories" do
-  render_item_list("repositories", "repositories", GithubRepositories)
+  accept = request.env["HTTP_ACCEPT"]
+  if accept == CONTENT_TYPE_JSON
+     serve_json_data(:repositories)
+  else
+    render_item_list("repositories", "repositories", GithubRepositories)
+  end
 end
 
 post "/:docpath" do

--- a/app.rb
+++ b/app.rb
@@ -71,6 +71,10 @@ def get_data_from_json_file(docpath, key, klass)
   )
 end
 
+def serve_json_data(docpath)
+  File.read(datafile(:helm_whatup))
+end
+
 # key is the name of the key in our datafile which contains the list of
 # elements we're interested in.
 def render_item_list(docpath, key, klass = ItemList)
@@ -107,7 +111,12 @@ get "/dashboard" do
 end
 
 get "/helm_whatup" do
-  render_item_list("helm_whatup", "clusters", HelmWhatup)
+  accept = request.env["HTTP_ACCEPT"]
+  if accept == CONTENT_TYPE_JSON
+     serve_json_data(:helm_whatup)
+  else
+    render_item_list("helm_whatup", "clusters", HelmWhatup)
+  end
 end
 
 get "/documentation" do

--- a/app.rb
+++ b/app.rb
@@ -91,6 +91,11 @@ def render_item_list(docpath, key, klass = ItemList)
   erb template, locals: locals
 end
 
+def accept_json?(request)
+  accept = request.env["HTTP_ACCEPT"]
+  accept == CONTENT_TYPE_JSON
+end
+
 ############################################################
 
 get "/" do
@@ -98,9 +103,7 @@ get "/" do
 end
 
 get "/dashboard" do
-  accept = request.env["HTTP_ACCEPT"]
-
-  if accept == CONTENT_TYPE_JSON
+  if accept_json?(request)
     dashboard_data.to_json
   else
     locals = dashboard_data.merge(
@@ -111,8 +114,7 @@ get "/dashboard" do
 end
 
 get "/helm_whatup" do
-  accept = request.env["HTTP_ACCEPT"]
-  if accept == CONTENT_TYPE_JSON
+  if accept_json?(request)
      serve_json_data(:helm_whatup)
   else
     render_item_list("helm_whatup", "clusters", HelmWhatup)
@@ -120,8 +122,7 @@ get "/helm_whatup" do
 end
 
 get "/documentation" do
-  accept = request.env["HTTP_ACCEPT"]
-  if accept == CONTENT_TYPE_JSON
+  if accept_json?(request)
      serve_json_data(:documentation)
   else
     render_item_list("documentation", "pages", Documentation)
@@ -129,8 +130,7 @@ get "/documentation" do
 end
 
 get "/terraform_modules" do
-  accept = request.env["HTTP_ACCEPT"]
-  if accept == CONTENT_TYPE_JSON
+  if accept_json?(request)
      serve_json_data(:terraform_modules)
   else
     render_item_list("terraform_modules", "out_of_date_modules")
@@ -138,8 +138,7 @@ get "/terraform_modules" do
 end
 
 get "/repositories" do
-  accept = request.env["HTTP_ACCEPT"]
-  if accept == CONTENT_TYPE_JSON
+  if accept_json?(request)
      serve_json_data(:repositories)
   else
     render_item_list("repositories", "repositories", GithubRepositories)

--- a/spec/dev_server_spec.rb
+++ b/spec/dev_server_spec.rb
@@ -50,11 +50,7 @@ describe "local dev server" do
   end
 
   it "serves dashboard json" do
-    response = fetch_url(dashboard_url, "application/json")
-    expect(response.code).to eq("200")
-    expect {
-      JSON.parse(response.body)
-    }.to_not raise_error
+    expect_json_data(dashboard_url, "data")
   end
 
   context "with malformed json data" do

--- a/spec/dev_server_spec.rb
+++ b/spec/dev_server_spec.rb
@@ -59,6 +59,10 @@ describe "local dev server" do
     expect_json_data(documentation_url, "pages")
   end
 
+  it "serves repositories json" do
+    expect_json_data(repositories_url, "repositories")
+  end
+
   it "serves dashboard json" do
     expect_json_data(dashboard_url, "data")
   end

--- a/spec/dev_server_spec.rb
+++ b/spec/dev_server_spec.rb
@@ -7,6 +7,15 @@ require "spec_helper"
 
 HELM_RELEASE_DATA_FILE = "data/helm_whatup.json"
 
+def expect_json_data(url, key)
+  response = fetch_url(url, "application/json")
+  expect(response.code).to eq("200")
+  expect {
+    data = JSON.parse(response.body)
+    expect(data).to have_key(key)
+  }.to_not raise_error
+end
+
 describe "local dev server" do
   let(:base_url) { "http://localhost:4567" }
   let(:api_key) { "soopersekrit" } # specified in makefile
@@ -34,6 +43,10 @@ describe "local dev server" do
       response = fetch_url(url)
       expect(response.code).to eq("200")
     end
+  end
+
+  it "serves helm_whatup json" do
+    expect_json_data(helm_whatup_url, "clusters")
   end
 
   it "serves dashboard json" do

--- a/spec/dev_server_spec.rb
+++ b/spec/dev_server_spec.rb
@@ -49,6 +49,14 @@ describe "local dev server" do
     expect_json_data(helm_whatup_url, "clusters")
   end
 
+  it "serves terraform_modules json" do
+    expect_json_data(terraform_modules_url, "out_of_date_modules")
+  end
+
+  it "serves documentation json" do
+    expect_json_data(documentation_url, "pages")
+  end
+
   it "serves dashboard json" do
     expect_json_data(dashboard_url, "data")
   end

--- a/spec/dev_server_spec.rb
+++ b/spec/dev_server_spec.rb
@@ -24,12 +24,14 @@ describe "local dev server" do
   let(:helm_whatup_url) { [base_url, "helm_whatup"].join("/") }
   let(:terraform_modules_url) { [base_url, "terraform_modules"].join("/") }
   let(:documentation_url) { [base_url, "documentation"].join("/") }
+  let(:repositories_url) { [base_url, "repositories"].join("/") }
 
   let(:urls) { [
     dashboard_url,
     helm_whatup_url,
     terraform_modules_url,
     documentation_url,
+    repositories_url,
   ] }
 
   it "redirects / to /dashboard" do


### PR DESCRIPTION
This will enable using the HOODAW data in scripts, for example to automatically
raise github issues to review documentation pages.