### PR TITLE
Parallelize the HOODAW updater

### DIFF
--- a/updater-image/update.sh
+++ b/updater-image/update.sh
@@ -5,10 +5,11 @@ API_KEY_SECRET="how-out-of-date-are-we-api-key"
 
 main() {
   set_api_key
-  helm_releases
-  terraform_modules
-  documentation
-  repositories
+  helm_releases &
+  terraform_modules &
+  documentation &
+  repositories &
+  wait # Wait until all background jobs have completed
 }
 
 set_kube_context() {


### PR DESCRIPTION
The HOODAW updater pipeline currently takes around 7 minutes to run.
This is tolerable, but as we add more and more reports, it is only going
to get slower.

This change parallelizes the updater, so that the different report tasks
run simultaneously. The `wait` statement means the shell script will not
exit until the slowest reporting task has finished.

This should speed up the pipeline, and hopefully ensure it stays
reasonably quick as we continue to add reports.
