### PR TITLE
Revert "Parallelize the HOODAW updater"

### DIFF
--- a/updater-image/update.sh
+++ b/updater-image/update.sh
@@ -5,11 +5,10 @@ API_KEY_SECRET="how-out-of-date-are-we-api-key"
 
 main() {
   set_api_key
-  helm_releases &
-  terraform_modules &
-  documentation &
-  repositories &
-  wait # Wait until all background jobs have completed
+  helm_releases
+  terraform_modules
+  documentation
+  repositories
 }
 
 set_kube_context() {


### PR DESCRIPTION
Reverts ministryofjustice/cloud-platform-how-out-of-date-are-we#42

This caused some helm charts to disappear from this page:
https://how-out-of-date-are-we.apps.live-1.cloud-platform.service.justice.gov.uk/helm_whatup

