### PR TITLE
Show cluster of orphan AWS resource

### DIFF
--- a/spec/orphaned_resources_spec.rb
+++ b/spec/orphaned_resources_spec.rb
@@ -15,8 +15,15 @@ describe OrphanedResources do
   let(:data) {
     {
       "orphaned_aws_resources" => {
-        "hosted_zones" => ["z1", "z2", "z3"],
-        "vpcs" => ["vpc1", "vpc2"]
+        "hosted_zones" => [
+          {"id" => "z1", "cluster" => "" },
+          {"id" => "z2", "cluster" => "" },
+          {"id" => "z3", "cluster" => "" },
+        ],
+        "vpcs" => [
+          {"id" => "v1", "cluster" => "test-1" },
+          {"id" => "v2", "cluster" => "test-2" },
+        ]
       }
     }
   }

--- a/views/orphaned_resources.erb
+++ b/views/orphaned_resources.erb
@@ -5,7 +5,10 @@
   <h2><%= snake_case_to_capitalised(resource_type) %></h2>
   <ul>
     <% list[resource_type].each do |item| %>
-      <li><%= item %></li>
+      <li>
+        <%= item["id"] %>
+        <%= item["cluster"] == "" ? "" : "(#{item["cluster"]})"%>
+      </li>
     <% end %>
   </ul>
 <% end %>


### PR DESCRIPTION
If the AWS resource tuple has a "cluster" value, show that on the web page.

related to https://github.com/ministryofjustice/cloud-platform-report-orphaned-resources/pull/5
