### PR TITLE
Link resources to AWS console page

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ make dev-server
 This will launch a local instance of the web server, and populate the data
 directory with the latest JSON files from the live instance.
 
-NB: You will need a workin ruby environment.
+NB: You will need a working ruby environment.
 
 ## Updating the docker images
 

--- a/views/orphaned_resources.erb
+++ b/views/orphaned_resources.erb
@@ -6,9 +6,18 @@
     <h2><%= snake_case_to_capitalised(resource_type) %></h2>
     <ul>
       <% list[resource_type].each do |item| %>
+        <%
+          text = item["id"]
+          text = item["cluster"] == "" ? text : text + " (#{item["cluster"]})"
+        %>
         <li>
-          <%= item["id"] %>
-          <%= item["cluster"] == "" ? "" : "(#{item["cluster"]})"%>
+          <% if item["aws_console_url"].to_s != "" %>
+            <a href="<%= item["aws_console_url"] %>">
+              <%= text %>
+            </a>
+          <% else %>
+            <%= text %>
+          <% end %>
         </li>
       <% end %>
     </ul>


### PR DESCRIPTION
depends on https://github.com/ministryofjustice/cloud-platform-report-orphaned-resources/pull/6

- Fix typo
- Link orphaned AWS resources to AWS console page
