### PR TITLE
Add page and layout to list Cloud Platform hosted services

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -46,7 +46,7 @@ def dashboard_data
     repositories: get_data_from_json_file("repositories", "repositories", GithubRepositories),
     terraform_modules: get_data_from_json_file("terraform_modules", "out_of_date_modules", ItemList),
     orphaned_resources: get_data_from_json_file("orphaned_resources", "orphaned_aws_resources", OrphanedResources),
-    hosted_services: get_data_from_json_file("hosted_services", "namespace_details_list", ItemList),
+    hosted_services: get_data_from_json_file("hosted_services", "namespace_details", ItemList),
   }
 
   updated_at = info.values.map(&:updated_at).sort.first

--- a/app.rb
+++ b/app.rb
@@ -46,6 +46,7 @@ def dashboard_data
     repositories: get_data_from_json_file("repositories", "repositories", GithubRepositories),
     terraform_modules: get_data_from_json_file("terraform_modules", "out_of_date_modules", ItemList),
     orphaned_resources: get_data_from_json_file("orphaned_resources", "orphaned_aws_resources", OrphanedResources),
+    hosted_services: get_data_from_json_file("hosted_services", "namespace_details_list", ItemList),
   }
 
   updated_at = info.values.map(&:updated_at).sort.first
@@ -60,6 +61,7 @@ def dashboard_data
         repositories: info[:repositories].todo_count,
         terraform_modules: info[:terraform_modules].todo_count,
         orphaned_resources: info[:orphaned_resources].todo_count,
+        hosted_services: info[:hosted_services].todo_count,
       },
       action_required: (todo_count > 0),
     }
@@ -160,6 +162,16 @@ get "/orphaned_resources" do
     render_item_list("orphaned_resources", "orphaned_aws_resources", OrphanedResources)
   end
 end
+
+
+get "/hosted_services" do
+  if accept_json?(request)
+     serve_json_data(:hosted_services)
+  else
+    render_item_list("hosted_services", "namespace_details")
+  end
+end
+
 
 get "/namespace_costs" do
   if accept_json?(request)

--- a/lib/hoodaw_utils.rb
+++ b/lib/hoodaw_utils.rb
@@ -1,4 +1,5 @@
 module HoodawUtils
+  GITHUB_TEAM_URL = "https://github.com/orgs/ministryofjustice/teams/"
   # "foo_bar_baz" => "Foo Bar Baz"
   def snake_case_to_capitalised(str)
     str.split("_").map(&:capitalize).join(" ")
@@ -12,6 +13,10 @@ module HoodawUtils
     whole, decimal = decimals(value).split(".")
     with_commas = whole.gsub(/\B(?=(...)*\b)/, ",")
     [with_commas, decimal].join(".")
+  end
+
+  def github_team_url(team_name)
+    link_to(team_name.to_s,GITHUB_TEAM_URL+team_name.to_s)
   end
 
   def link_each_to(domain_names)

--- a/lib/hoodaw_utils.rb
+++ b/lib/hoodaw_utils.rb
@@ -13,6 +13,20 @@ module HoodawUtils
     with_commas = whole.gsub(/\B(?=(...)*\b)/, ",")
     [with_commas, decimal].join(".")
   end
+
+  def link_each_to(domain_names)
+    domain_names.map { |domain_name| link_to(domain_name,"https://"+domain_name) }
+                .join("<br> ")
+  end
+
+  def link_to(text, href)
+    "<a href='#{href}'>#{split(text)}</a>" 
+  end
+
+  def split(text)
+    text.to_s.split('/').last
+  end
+
 end
 
 helpers HoodawUtils

--- a/lib/hoodaw_utils.rb
+++ b/lib/hoodaw_utils.rb
@@ -26,16 +26,13 @@ module HoodawUtils
                 .join("<br/> ")
   end
 
-  def link_to_repo(text, href)
-    "<a href='#{href}'>#{split(text)}</a>" 
+  def link_to_repo(repo, url)
+    name = repo.to_s.split("/").last
+    link_to(name, url)
   end
 
   def link_to(text, href)
     "<a href='#{href}'>#{text}</a>" 
-  end
-
-  def split(text)
-    text.to_s.split('/').last
   end
 
 end

--- a/lib/hoodaw_utils.rb
+++ b/lib/hoodaw_utils.rb
@@ -15,17 +15,23 @@ module HoodawUtils
     [with_commas, decimal].join(".")
   end
 
-  def github_team_url(team_name)
-    link_to(team_name.to_s,GITHUB_TEAM_URL+team_name.to_s)
+  def link_to_github_team(team_name)
+    if !team_name.nil? 
+      link_to(team_name.to_s,GITHUB_TEAM_URL+team_name.to_s)
+    end
   end
 
-  def link_each_to(domain_names)
+  def links_to_domain_names(domain_names)
     domain_names.map { |domain_name| link_to(domain_name,"https://"+domain_name) }
-                .join("<br> ")
+                .join("<br/> ")
+  end
+
+  def link_to_repo(text, href)
+    "<a href='#{href}'>#{split(text)}</a>" 
   end
 
   def link_to(text, href)
-    "<a href='#{href}'>#{split(text)}</a>" 
+    "<a href='#{href}'>#{text}</a>" 
   end
 
   def split(text)

--- a/lib/hosted_services.rb
+++ b/lib/hosted_services.rb
@@ -1,0 +1,5 @@
+class HostedServices < ItemList
+  def todo_count
+    namespace_details.inject(0) {|sum, (namespace, items)| sum += items.size}
+  end
+end

--- a/updater-image/update.sh
+++ b/updater-image/update.sh
@@ -9,6 +9,7 @@ main() {
   terraform_modules
   documentation
   repositories
+  hosted_services
 }
 
 set_kube_context() {
@@ -49,6 +50,11 @@ documentation() {
 
 repositories() {
   curl -H "X-API-KEY: ${API_KEY}" -d "$(cloud-platform-repository-checker)" ${DATA_URL}/repositories
+}
+
+
+hosted_services() {
+  curl -H "X-API-KEY: ${API_KEY}" -d "$(cloud-platform-environments-checker)" ${DATA_URL}/hosted_services
 }
 
 main

--- a/updater-image/update.sh
+++ b/updater-image/update.sh
@@ -52,9 +52,4 @@ repositories() {
   curl -H "X-API-KEY: ${API_KEY}" -d "$(cloud-platform-repository-checker)" ${DATA_URL}/repositories
 }
 
-
-hosted_services() {
-  curl -H "X-API-KEY: ${API_KEY}" -d "$(cloud-platform-environments-checker)" ${DATA_URL}/hosted_services
-}
-
 main

--- a/views/hosted_services.erb
+++ b/views/hosted_services.erb
@@ -1,0 +1,37 @@
+<h1>Hosted Services (<%= list.size %>)</h1>
+
+<% if list.any? %>
+  <div class="table-responsive">
+    <table class="table">
+  <thead class="thead-dark">
+    <tr>
+      <th scope="col">Namespace</th>
+      <th scope="col">Application</th>
+      <th scope="col">Business unit</th>
+      <th scope="col">Team name</th>
+       <th scope="col">Slack channel</th>
+      <th scope="col">Source code</th>
+      <th scope="col">Domain names</th>
+    </tr>
+  </thead>
+  <tbody>
+  <% list.each do |service| %>
+    <tr>
+      <th scope="row"><%= service["namespace"] %></th>
+      <td><%= service["application"] %></td>
+      <td><%= service["business_unit"] %></td>
+      <td><%= service["team_name"] %></td>
+      <td><%= service["team_slack_channel"] %></td>
+      <td><%= service["github_url"] %></td>
+      <td><%= service["domain_names"].join(", ") %></td>
+    </tr>
+    <% end %>
+    </tbody>
+    </table>
+    </div>
+    <% else %>
+  <h1>
+    Awaiting data
+  </h1>
+
+<% end %>

--- a/views/hosted_services.erb
+++ b/views/hosted_services.erb
@@ -22,8 +22,8 @@
       <td><%= service["business_unit"] %></td>
       <td><%= service["team_name"] %></td>
       <td><%= service["team_slack_channel"] %></td>
-      <td><%= service["github_url"] %></td>
-      <td><%= service["domain_names"].join(", ") %></td>
+      <td><%= link_to service["github_url"], service["github_url"] %></td>
+      <td><%= link_each_to service["domain_names"] %></td>
     </tr>
     <% end %>
     </tbody>

--- a/views/hosted_services.erb
+++ b/views/hosted_services.erb
@@ -20,10 +20,10 @@
       <th scope="row"><%= service["namespace"] %></th>
       <td><%= service["application"] %></td>
       <td><%= service["business_unit"] %></td>
-      <td><%= github_team_url service["team_name"] %></td>
+      <td><%= link_to_github_team service["team_name"] %></td>
       <td><%= service["team_slack_channel"] %></td>
-      <td><%= link_to service["github_url"], service["github_url"] %></td>
-      <td><%= link_each_to service["domain_names"] %></td>
+      <td><%= link_to_repo service["github_url"], service["github_url"] %></td>
+      <td><%= links_to_domain_names service["domain_names"] %></td>
     </tr>
     <% end %>
     </tbody>

--- a/views/hosted_services.erb
+++ b/views/hosted_services.erb
@@ -20,7 +20,7 @@
       <th scope="row"><%= service["namespace"] %></th>
       <td><%= service["application"] %></td>
       <td><%= service["business_unit"] %></td>
-      <td><%= service["team_name"] %></td>
+      <td><%= github_team_url service["team_name"] %></td>
       <td><%= service["team_slack_channel"] %></td>
       <td><%= link_to service["github_url"], service["github_url"] %></td>
       <td><%= link_each_to service["domain_names"] %></td>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -39,6 +39,9 @@
           <li class="nav-item <%= active_nav == "namespace_costs" ? "active" : "" %>">
             <a class="nav-link" href="/namespace_costs">Namespace Costs</a>
           </li>
+             <li class="nav-item <%= active_nav == "hosted_services" ? "active" : "" %>">
+            <a class="nav-link" href="/hosted_services">Hosted Services</a>
+          </li>
         </ul>
 
         <ul class="navbar-nav justify-content-end">


### PR DESCRIPTION
The data is pushed from cloud-platform-environments-checker repo and triggered through concourse pipeline

Related to: https://github.com/ministryofjustice/cloud-platform/issues/2289