### PR TITLE
Use batch_get_item DynamoDB function

### DIFF
--- a/fetch-data-from-dynamodb.rb
+++ b/fetch-data-from-dynamodb.rb
@@ -1,0 +1,17 @@
+#!/usr/bin/env ruby
+
+# Monkey-patch Object so that we can require lib/hoodaw.rb without requiring
+# sinatra
+class Object
+  def helpers(_)
+  end
+end
+
+require "bundler/setup"
+require "pry-byebug"
+require "json"
+require "./lib/hoodaw"
+
+store = Dynamodb.new
+files = store.list_files
+store.retrieve_files(files).each { |file, data| puts file; File.write(file, data["content"]) }

--- a/lib/filestore.rb
+++ b/lib/filestore.rb
@@ -13,6 +13,16 @@ class Filestore
     File.read(file)
   end
 
+  def retrieve_files(filenames)
+    filenames.inject({}) do |hash, filename|
+      hash[filename] = {
+        "content" => retrieve_file(filename),
+        "stored_at" => stored_at(filename),
+      }
+      hash
+    end
+  end
+
   def stored_at(file)
     File.stat(file).mtime
   end

--- a/makefile
+++ b/makefile
@@ -15,11 +15,11 @@ docker-dev-server:
 test:
 	rspec
 
+# This requires that the following ENV vars are set:
+#   * DYNAMODB_TABLE_NAME
+#   * DYNAMODB_ACCESS_KEY_ID
+#   * DYNAMODB_SECRET_ACCESS_KEY
 fetch-live-json-datafiles:
 	mkdir -p data/namespace/costs
-	pod=$$(kubectl -n how-out-of-date-are-we get pods -o name); \
-		for file in $$(kubectl -n how-out-of-date-are-we exec $${pod} find data); do \
-		  echo $${file}; \
-			kubectl -n how-out-of-date-are-we exec $${pod} cat $${file} > $${file}; \
-		done
+	./fetch-data-from-dynamodb.rb
 


### PR DESCRIPTION
This change replaces ~220 `get_item` calls to dynamodb, when building the namespace costs page, with 3 calls to `batch_get_item`. This means the page loads fast enough that we don't need the caching logic anymore.