### PR TITLE
Remove pry-byebug as a development dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,4 @@ gem "aws-sdk-dynamodb"
 
 group :development do
   gem "rspec"
-  gem "pry-byebug"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,72 +2,61 @@ GEM
   remote: https://rubygems.org/
   specs:
     aws-eventstream (1.1.0)
-    aws-partitions (1.368.0)
-    aws-sdk-core (3.105.0)
+    aws-partitions (1.405.0)
+    aws-sdk-core (3.110.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-dynamodb (1.52.0)
-      aws-sdk-core (~> 3, >= 3.99.0)
+    aws-sdk-dynamodb (1.58.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.2.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    backports (3.18.1)
-    byebug (11.1.3)
-    coderay (1.1.3)
     diff-lcs (1.4.4)
     jmespath (1.4.0)
-    method_source (1.0.0)
     multi_json (1.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
-    pry (0.13.1)
-      coderay (~> 1.1)
-      method_source (~> 1.0)
-    pry-byebug (3.9.0)
-      byebug (~> 11.0)
-      pry (~> 0.13.0)
     rack (2.2.3)
-    rack-protection (2.0.8.1)
+    rack-protection (2.1.0)
       rack
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    rspec (3.10.0)
+      rspec-core (~> 3.10.0)
+      rspec-expectations (~> 3.10.0)
+      rspec-mocks (~> 3.10.0)
+    rspec-core (3.10.0)
+      rspec-support (~> 3.10.0)
+    rspec-expectations (3.10.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.10.0)
+    rspec-mocks (3.10.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
+      rspec-support (~> 3.10.0)
+    rspec-support (3.10.0)
     ruby2_keywords (0.0.2)
-    sinatra (2.0.8.1)
+    sinatra (2.1.0)
       mustermann (~> 1.0)
-      rack (~> 2.0)
-      rack-protection (= 2.0.8.1)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
       tilt (~> 2.0)
-    sinatra-contrib (2.0.8.1)
-      backports (>= 2.8.2)
+    sinatra-contrib (2.1.0)
       multi_json
       mustermann (~> 1.0)
-      rack-protection (= 2.0.8.1)
-      sinatra (= 2.0.8.1)
+      rack-protection (= 2.1.0)
+      sinatra (= 2.1.0)
       tilt (~> 2.0)
     tilt (2.0.10)
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   aws-sdk-dynamodb
-  pry-byebug
   rspec
   sinatra
   sinatra-contrib
 
 BUNDLED WITH
-   2.1.4
+   2.2.0

--- a/app.rb
+++ b/app.rb
@@ -9,7 +9,6 @@ CONTENT_TYPE_JSON = "application/json"
 
 if development?
   require "sinatra/reloader"
-  require "pry-byebug"
 end
 
 def update_json_data(store, docpath, request)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,6 @@ end
 require "net/http"
 require "uri"
 require "json"
-require "pry-byebug"
 require "sinatra"
 require "./lib/hoodaw"
 require "./lib/dashboard_reporter"


### PR DESCRIPTION
Version 2.32 of HOODAW crashes, complaining about
a missing version of pry-byebug

I think I just needed to recreate the Gemfile.lock
which I have done in this PR, but I've removed the
dependency anyway, which should also make the 
docker image smaller.