### PR TITLE
Fix `bundle install` problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM ruby:2.6-alpine
+FROM ruby:2.7-alpine
 
 RUN addgroup -g 1000 -S appgroup \
   && adduser -u 1000 -S appuser -G appgroup \
   && apk update \
-  && gem install bundler \
-  && bundle config set without 'development'
+  && gem install bundler
 
 WORKDIR /app
 

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,4 @@ git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 gem "sinatra"
 gem "sinatra-contrib"
 gem "aws-sdk-dynamodb"
-
-group :development do
-  gem "rspec"
-end
+gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
 
 PLATFORMS
   ruby
-  x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   aws-sdk-dynamodb


### PR DESCRIPTION
There seems to be a problem with the current
version of bundler. AFAICT, it's partially-
ignoring the
```
bundle config set without 'development'
```
command. So, It's specifying that, e.g. rspec and
pry-byebug are *supposed to be* installed (which 
they aren't, for the docker image that runs on
live-1), but not actually installing those gems on
the image.

So, when app.rb is executed, and tries to run 
`bundler/setup`, it fails because the development
gems aren't installed.

I'm sure there is a smarter way to fix this, but
for now I'm just removing the development group
from the gemfile, and installing rspec in the
docker image, even though it's not needed for the
web application - only for the tests.

I tried to do the same thing with pry-byebug, but
I think there are more dependencies required, 
because `bundle install` fails when I include that
gem in the gemfile. So, I'm just leaving it out.