### PR TITLE
Display orphaned kops cluster instances

### DIFF
--- a/cloud-platform-reports-cronjobs/Chart.yaml
+++ b/cloud-platform-reports-cronjobs/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports-cronjobs
 description: Cronjobs to provide data to the Cloud Platform Reports web application
 type: application
 version: 0.1.0
-appVersion: "3.2"
+appVersion: "3.3"

--- a/cloud-platform-reports/Chart.yaml
+++ b/cloud-platform-reports/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports
 description: Cloud Platform Reports web application and data providers
 type: application
 version: 0.1.0
-appVersion: "3.2"
+appVersion: "3.3"

--- a/reports/orphaned-aws-resources/.gitignore
+++ b/reports/orphaned-aws-resources/.gitignore
@@ -1,0 +1,1 @@
+state-files/

--- a/reports/orphaned-aws-resources/lib/orphaned_resources/aws_resources.rb
+++ b/reports/orphaned-aws-resources/lib/orphaned_resources/aws_resources.rb
@@ -6,6 +6,8 @@ module OrphanedResources
     EC2_HOME = "https://eu-west-2.console.aws.amazon.com/ec2/v2/home?region=eu-west-2"
     RDS_HOME = "https://eu-west-2.console.aws.amazon.com/rds/home?region=eu-west-2"
 
+    KOPS_CLUSTER_INSTANCES_URL = "https://eu-west-2.console.aws.amazon.com/ec2/v2/home?region=eu-west-2#Instances:tag:KubernetesCluster"
+
     NAT_GATEWAY_URL = VPC_HOME + "#NatGatewayDetails:natGatewayId="
     INTERNET_GATEWAY_URL = VPC_HOME + "#InternetGateway:internetGatewayId="
     ROUTE_TABLE_URL = VPC_HOME + "#RouteTables:search="
@@ -48,7 +50,11 @@ module OrphanedResources
                             end
 
                             h.map do |cluster, instances|
-                              { cluster: cluster, instances: instances }
+                              {
+                                cluster: cluster,
+                                instances: instances,
+                                href: [KOPS_CLUSTER_INSTANCES_URL, cluster].join("="),
+                              }
                             end
                           end
     end

--- a/reports/orphaned-aws-resources/lib/orphaned_resources/reporter.rb
+++ b/reports/orphaned-aws-resources/lib/orphaned_resources/reporter.rb
@@ -29,6 +29,7 @@ module OrphanedResources
         route_table_associations: compare(:route_table_associations),
         rds: compare(:rds),
         rds_cluster: compare(:rds_cluster),
+        kops_cluster: orphaned_kops_clusters,
       }
     end
 
@@ -39,6 +40,13 @@ module OrphanedResources
         @aws.send(method),
         @terraform.send(method)
       ).sort
+    end
+
+    def orphaned_kops_clusters
+      a = @aws.kops_clusters
+      t = @terraform.kops_clusters
+      orphaned = (a.map { |i| i[:cluster]}) - (t.map { |i| i[:cluster]})
+      a.filter { |c| orphaned.include?(c[:cluster]) }
     end
   end
 end

--- a/views/orphaned_resources.erb
+++ b/views/orphaned_resources.erb
@@ -8,7 +8,11 @@
   <h2>Kops Cluster EC2 Intances</h2>
   <ul>
     <% kops_clusters.each do |k| %>
-      <li><%= %[#{k["cluster"]} (#{k["instances"]} instances)] %></li>
+      <li>
+        <a href="<%= k["href"] %>">
+          <%= %[#{k["cluster"]} (#{k["instances"]} instances)] %>
+        </a>
+      </li>
     <% end %>
   </ul>
 

--- a/views/orphaned_resources.erb
+++ b/views/orphaned_resources.erb
@@ -4,6 +4,14 @@
 </p>
 
 <% if list.is_a?(Hash) %>
+  <% kops_clusters = list.delete("kops_cluster") %>
+  <h2>Kops Cluster EC2 Intances</h2>
+  <ul>
+    <% kops_clusters.each do |k| %>
+      <li><%= %[#{k["cluster"]} (#{k["instances"]} instances)] %></li>
+    <% end %>
+  </ul>
+
   <% list.keys.sort.each do |resource_type| %>
     <h2><%= snake_case_to_capitalised(resource_type) %></h2>
     <ul>


### PR DESCRIPTION
This PR will amend the app. to find and display any EC2 instances that have been left behind after incomplete deletions of kops clusters.

> At the time of writing, no such instances exist

- Git ignore state-files/
- Derive list of kops clusters from terraform state
- Derive a list of kops clusters from EC2 tags
- Identify kops clusters in AWS but not in terraform
- Show orphaned kops cluster instances in report
- Include URL to AWS console page for cluster EC2s
- Display cluster as a link to the AWS console page
- Update the release number
