### PR TITLE
Move reports frontend to the `live` cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ See the [about page](views/about.erb) for more details.
 
 The application consists of 2 Helm charts - one for the [web application](cloud-platform-reports), and one for the [cronjobs](cloud-platform-reports-cronjobs) which provide the data.
 
-The web application is deployed to the `live-1` cluster. The cronjobs are deployed to the `concourse-main` namespace of the `manager` cluster.
+The web application is deployed to the `live` cluster. The cronjobs are deployed to the `concourse-main` namespace of the `manager` cluster.
 
 ## Pre-requisites
 
-* `live-1` kube context
+* access to perform `awscli` commands in the account `cloud-platform-aws`
+* `live` kube context
 * `manager` kube context
 * `cloud-platform-reports-cronjobs/secrets.yaml` file containing Docker Hub credentials
 * `cloud-platform-reports/secrets.yaml` file defining the web application API key
@@ -23,7 +24,7 @@ The web application API key is required by both the web application and the
 cronjobs which post the report data. So the
 `cloud-platform-reports/secrets.yaml` file is also used when deploying the
 `cloud-platform-reports-cronjobs` helm chart. Equivalent secrets are created in
-both the `live-1/<web app>` and `manager/concourse-main` namespaces.
+both the `live/<web app>` and `manager/concourse-main` namespaces.
 
 ## Deploying
 

--- a/cloud-platform-reports/values-dev.yaml
+++ b/cloud-platform-reports/values-dev.yaml
@@ -1,2 +1,2 @@
 ingress:
-  hostname: cloud-platform-reports.apps.live-1.cloud-platform.service.justice.gov.uk
+  hostname: cloud-platform-reports.apps.live.cloud-platform.service.justice.gov.uk

--- a/makefile
+++ b/makefile
@@ -12,7 +12,7 @@ upgrade:
 	make upgrade-cronjobs
 
 deploy-webapp:
-	kubectl config use-context live-1 \
+	aws eks update-kubeconfig --name live \
 	  && helm install \
 			--generate-name \
 			--namespace $(PROD_NAMESPACE) \
@@ -54,7 +54,7 @@ dev-upgrade:
 	make dev-upgrade-cronjobs
 
 dev-deploy-webapp:
-	kubectl config use-context live-1 \
+	aws eks update-kubeconfig --name live \
 	  && helm install \
 			--generate-name \
 			--namespace $(DEV_NAMESPACE) \


### PR DESCRIPTION
Overview
---
This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2857 and relates to the migration of the reports frontend from cluster `live-1` to `live`. This work has already been carried out, this PR contains the necessary changes to the makefile and README to reflect these changes.