### PR TITLE
Enclose json output with [] for one entry

### DIFF
--- a/reports/orphaned-terraform-statefiles/lib/cluster_lister.rb
+++ b/reports/orphaned-terraform-statefiles/lib/cluster_lister.rb
@@ -14,6 +14,13 @@ class ClusterLister
 
   def kops_clusters
     json = `kops get clusters --output json`
+
+    # If the output json has one cluster it doesnot enclose [] and hence map cannot 
+    # dig into metadata. Check if has enclosed [] if not add a []
+    if json.chr != '[' 
+      json = "[" + json + "]"
+    end
+
     JSON.parse(json)
       .map {|h| h.dig("metadata", "name")}
       .map {|str| str.split(".").first}


### PR DESCRIPTION
This fixes error  `dig': no implicit conversion of String into Integer (TypeError).  when json output with one cluster.

Fixes: https://github.com/ministryofjustice/cloud-platform/issues/3053