### PR TITLE
Add resource name and fix broken namespace

### DIFF
--- a/reports/ingress-weighting/main.go
+++ b/reports/ingress-weighting/main.go
@@ -75,7 +75,8 @@ func IngressWithoutAnnotation(clientset *kubernetes.Clientset) ([]byte, error) {
 		if _, exists := i.Annotations[*annotation]; !exists {
 			for _, v := range i.Spec.TLS {
 				m := make(map[string]string)
-				m["namespace"] = i.GetName()
+				m["namespace"] = i.Namespace
+				m["resource"] = i.GetName()
 				m["hostname"] = v.Hosts[0]
 				s = append(s, m)
 			}

--- a/views/ingress_weighting.erb
+++ b/views/ingress_weighting.erb
@@ -4,6 +4,7 @@
   <thead class="thead-dark">
     <tr>
       <th scope="col">Namespace</th>
+      <th scope="col">Ingress Name</th>
       <th scope="col">Host</th>
     </tr>
   </thead>
@@ -11,6 +12,7 @@
   <% list.each do |service| %>
     <tr>
       <td><%= service["namespace"] %></td>
+      <td><%= service["resource"] %></td>
       <td><%= service["hostname"] %></td>
     </tr>
   <% end %>


### PR DESCRIPTION
This commit fixes the broken namespace name key, which was interpreting
the namespace as the resource name. It would make sense to include the
namepsace, resource and host names in the report, so "ingress name" has
been included in the sinatra view.