### PR TITLE
Add QueryApi function and document exported package

### DIFF
--- a/reports/pkg/hoodaw/document.go
+++ b/reports/pkg/hoodaw/document.go
@@ -1,0 +1,4 @@
+/*
+Package hoodaw implements operators to interact with the How-out-of-date-are-we API.
+*/
+package hoodaw //import "github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/reports/pkg/hoodaw"

--- a/reports/pkg/hoodaw/hoodaw.go
+++ b/reports/pkg/hoodaw/hoodaw.go
@@ -2,8 +2,44 @@ package hoodaw
 
 import (
 	"bytes"
+	"io/ioutil"
 	"net/http"
+	"time"
 )
+
+const host = "https://reports.cloud-platform.service.justice.gov.uk/"
+
+// QueryApi takes the name of an endpoint and uses the http package to
+// return a slice of bytes.
+func QueryApi(endPoint string) ([]byte, error) {
+	client := &http.Client{
+		Timeout: time.Second * 2,
+	}
+
+	req, err := http.NewRequest(http.MethodGet, host+endPoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Add("User-Agent", "hoodaw-pkg")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
 
 // postToApi takes a slice of bytes as an argument and attempts to POST it to the REST API
 // provided by HOODAW. The slice of bytes should contain json using the guidelines outlined

--- a/reports/pkg/hoodaw/hoodaw_test.go
+++ b/reports/pkg/hoodaw/hoodaw_test.go
@@ -1,0 +1,40 @@
+package hoodaw
+
+import (
+	"testing"
+)
+
+func TestQueryApi(t *testing.T) {
+	type args struct {
+		endPoint string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "Test correct endpoint",
+			args: args{
+				endPoint: "ingress-weighting",
+			},
+			wantErr: false,
+		},
+		{
+			name: "Test incorrect endpoint",
+			args: args{
+				endPoint: "%",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := QueryApi(tt.args.endPoint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("QueryApi() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+		})
+	}
+}


### PR DESCRIPTION
I've found myself writing the same block of code to query the hoodaw
API. This commit creates a function to make any future code pragmatic.