### PR TITLE
Add trailing slash to user-guide to fix getaddr error

### DIFF
--- a/cloud-platform-reports-cronjobs/templates/documentation.yaml
+++ b/cloud-platform-reports-cronjobs/templates/documentation.yaml
@@ -18,7 +18,7 @@ spec:
             env:
             {{- include "cloud-platform-reports-cronjobs.hoodaw-credentials" . | indent 12 }}
             - name: DOCUMENTATION_SITES
-              value: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk"
+              value: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk/"
             args:
               - /app/bin/post-data.sh
           restartPolicy: OnFailure


### PR DESCRIPTION
The documentation report throw error `Failed to open TCP connection to user-guide.cloud-platform.service.justice.gov.ukdocumentation:443.`. Something changed the way on http ruby library to getAddrInfo and needed a / at the end.
