### PR TITLE
Update helm list command to use max -m

### DIFF
--- a/reports/helm-releases/main.go
+++ b/reports/helm-releases/main.go
@@ -92,7 +92,7 @@ func main() {
 
 // executeHelmList execute helm list all namespaces amd return output as string
 func executeHelmList() (string, error) {
-	cmd := exec.Command("helm", "list", "--all-namespaces", "-o", "json")
+	cmd := exec.Command("helm", "list", "--all-namespaces", "-m", "1000", "-o", "json")
 
 	var out bytes.Buffer
 	var stderr bytes.Buffer


### PR DESCRIPTION
We are missing some charts in "live", this is because, the maximum number of releases to fetch (default 256), our current helm list is more than 400 currently.

helm list default value:
https://helm.sh/docs/helm/helm_list/#options