### PR TITLE
Fix runbook url to remove leading ./

### DIFF
--- a/cloud-platform-reports-cronjobs/Chart.yaml
+++ b/cloud-platform-reports-cronjobs/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports-cronjobs
 description: Cronjobs to provide data to the Cloud Platform Reports web application
 type: application
 version: 0.2.1
-appVersion: "3.13.5"
+appVersion: "3.13.6"

--- a/cloud-platform-reports-cronjobs/templates/documentation.yaml
+++ b/cloud-platform-reports-cronjobs/templates/documentation.yaml
@@ -18,7 +18,7 @@ spec:
             env:
             {{- include "cloud-platform-reports-cronjobs.hoodaw-credentials" . | indent 12 }}
             - name: DOCUMENTATION_SITES
-              value: "https://runbooks.cloud-platform.service.justice.gov.uk https://user-guide.cloud-platform.service.justice.gov.uk/"
+              value: "https://runbooks.cloud-platform.service.justice.gov.uk/ https://user-guide.cloud-platform.service.justice.gov.uk/"
             args:
               - /app/bin/post-data.sh
           restartPolicy: OnFailure

--- a/cloud-platform-reports/Chart.yaml
+++ b/cloud-platform-reports/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports
 description: Cloud Platform Reports web application and data providers
 type: application
 version: 0.1.2
-appVersion: "3.13.5"
+appVersion: "3.13.6"

--- a/reports/documentation/bin/documentation-pages-to-review.rb
+++ b/reports/documentation/bin/documentation-pages-to-review.rb
@@ -19,7 +19,7 @@ def urls_and_review_statuses(url, root_url, seen = {})
   doc = get_nokogiri_doc(url)
   seen[url] = needs_review?(doc)
   get_links(doc).map { |path| urls_and_review_statuses([root_url, path].join, root_url, seen) }
-
+  
   seen
 end
 
@@ -63,8 +63,8 @@ def normalise_href(href)
   # ignore links which are external, or to in-page anchors
   return nil if href[0] == "#" || ["/", "http", "mail", "/ima"].include?(href[0, 4])
 
-  # Remove any trailing anchors, or "/"
-  target = href.sub(/\#.*/, "").sub(/\/$/, "")
+  # Remove any trailing anchors, or "/" and leading "./" 
+  target = href.sub(/\#.*/, "").sub(/\/$/, "").sub(/\.*/, "").sub(/\/*/, "")
 
   # Ignore links which don't point to html files
   /html$/.match?(target) ? target : nil


### PR DESCRIPTION
The runbook urls refered in `href` are with pattern `./filename.url`. Remove the `./ before joining to the root url which form the list of runbooks pages which needs review.