### PR TITLE
chore: 🤖 upgrade helm version

### DIFF
--- a/cloud-platform-reports-cronjobs/Chart.yaml
+++ b/cloud-platform-reports-cronjobs/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports-cronjobs
 description: Cronjobs to provide data to the Cloud Platform Reports web application
 type: application
 version: 0.2.3
-appVersion: "4.0.1"
+appVersion: "4.0.2"

--- a/cloud-platform-reports-cronjobs/templates/helm-releases.yaml
+++ b/cloud-platform-reports-cronjobs/templates/helm-releases.yaml
@@ -25,4 +25,12 @@ spec:
             - /bin/sh
             - -c
             - ./helm-releases
+            resources:
+              requests:
+                memory: "1000Mi"
+                cpu: "1"
+              limits:
+                memory: "2000Mi"
+                cpu: "2m"
+
           restartPolicy: OnFailure

--- a/cloud-platform-reports/Chart.yaml
+++ b/cloud-platform-reports/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports
 description: Cloud Platform Reports web application and data providers
 type: application
 version: 1.0.0
-appVersion: "4.0.1"
+appVersion: "4.0.2"

--- a/reports/helm-releases/Dockerfile
+++ b/reports/helm-releases/Dockerfile
@@ -14,7 +14,7 @@ RUN go build .
 FROM alpine:3.11.0
 
 ENV \
-  HELM_VERSION=3.4.0
+  HELM_VERSION=3.12.3
 
 RUN \
   apk add \

--- a/reports/helm-releases/main.go
+++ b/reports/helm-releases/main.go
@@ -44,7 +44,6 @@ type helmRelease struct {
 type resourceMap map[string]interface{}
 
 func main() {
-
 	contexts := []string{*ctxLive, *ctxManager}
 
 	var clusters []resourceMap
@@ -108,7 +107,6 @@ func executeHelmList() (string, error) {
 
 // getNamespaces takes json output and get list of namespaces
 func getNamespaces(helmListJson string) ([]string, error) {
-
 	var namespaces []helmNamespace
 	json.Unmarshal([]byte(helmListJson), &namespaces)
 
@@ -168,7 +166,6 @@ func helmReleasesInNamespace(namespace string) ([]helmRelease, error) {
 	}
 
 	return rel["releases"], nil
-
 }
 
 // BuildJsonMap takes a slice of maps and return a json encoded map


### PR DESCRIPTION
This cronjob was failing to update because it was `OOMKilled` since Aug 17.

When running `helm list --all-namespaces` the command is erroring with `Killed`