### PR TITLE
Bump charts

### DIFF
--- a/cloud-platform-reports-cronjobs/Chart.yaml
+++ b/cloud-platform-reports-cronjobs/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports-cronjobs
 description: Cronjobs to provide data to the Cloud Platform Reports web application
 type: application
 version: 0.11.3
-appVersion: "4.5.0"
+appVersion: "4.3.2"

--- a/cloud-platform-reports-cronjobs/Chart.yaml
+++ b/cloud-platform-reports-cronjobs/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports-cronjobs
 description: Cronjobs to provide data to the Cloud Platform Reports web application
 type: application
 version: 0.11.3
-appVersion: "4.3.2"
+appVersion: "4.5.0"

--- a/cloud-platform-reports/Chart.yaml
+++ b/cloud-platform-reports/Chart.yaml
@@ -3,4 +3,4 @@ name: cloud-platform-reports
 description: Cloud Platform Reports web application and data providers
 type: application
 version: 1.2.0
-appVersion: "4.4.0"
+appVersion: "4.5.0"


### PR DESCRIPTION
- user requested json access to namespace costs https://github.com/ministryofjustice/cloud-platform-how-out-of-date-are-we/pull/258

This is blocked as the release fails with the following error:

```
/usr/local/bundle/gems/bundler-2.5.16/lib/bundler/self_manager.rb:92:in `exec': No such file or directory - app.rb (Errno::ENOENT)
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler/self_manager.rb:92:in `block in restart_with'
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler.rb:412:in `block in with_original_env'
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler.rb:684:in `with_env'
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler.rb:412:in `with_original_env'
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler/self_manager.rb:91:in `restart_with'
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler/self_manager.rb:12:in `restart_with_locked_bundler_if_needed'
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler.rb:171:in `auto_switch'
        from /usr/local/bundle/gems/bundler-2.5.16/lib/bundler/setup.rb:9:in `<top (required)>'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from <internal:/usr/local/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
        from app.rb:3:in `<main>'

```